### PR TITLE
implement submit_answer view

### DIFF
--- a/thresher/serializers.py
+++ b/thresher/serializers.py
@@ -128,14 +128,9 @@ class GenericSubmittedAnswerField(serializers.Field):
               "tb" : TBSubmittedAnswer,
               "dt" : DTSubmittedAnswer}
     
-    serializers = {"mc" : MCSubmittedAnswerSerializer,
-                   "cl": CLSubmittedAnswerSerializer,
-                   "tb" : TBSubmittedAnswerSerializer,
-                   "dt" : DTSubmittedAnswerSerializer}
-
     def to_representation(self, obj):
         question_type = obj.question.type
-        serializer = self.serializers[question_type]
+        serializer = answerizers[question_type]
 
         return serializer(obj).data
 
@@ -146,7 +141,7 @@ class GenericSubmittedAnswerField(serializers.Field):
         except:
             raise serializers.ValidationError('Invalid Question ID')
 
-        serializer = self.serializers[question.type]
+        serializer = answerizers[question.type]
         serialized_instance = serializer(data=data)
         if not serialized_instance.is_valid():
             raise serializers.ValidationError(serialized_instance.errors)
@@ -287,3 +282,8 @@ class TopicSerializer(serializers.ModelSerializer):
         fields = ('id', 'parent', 'name',
                   'order', 'glossary', 'instructions', 
                   'related_questions', 'article_highlight')
+
+answerizers = {"mc" : MCSubmittedAnswerSerializer,
+               "cl" : CLSubmittedAnswerSerializer,
+               "tb" : TBSubmittedAnswerSerializer,
+               "dt" : DTSubmittedAnswerSerializer}


### PR DESCRIPTION
@floraxue and @nickbadams : I believe this implementation of `submit_answer` will do what you wanted, however you'll find there other issues in the code elsewhere:

```
Exception Value:     to_internal_value() must be implemented.
Exception Location:  /usr/local/lib/python2.7/site-packages/rest_framework/fields.py in to_internal_value, line 354
```

This new issue is due to [serializers.py#L58](https://github.com/aculich/text-thresher-backend/blob/submit_answer_endpoint/thresher/serializers.py#L58):

``` python
class UserSerializer(serializers.ModelSerializer):
    password = serializers.Field(write_only=True)
```

Because the `serializers.Field` class does not implement `to_internal_value()`.

Since you or others on your team are probably more familiar with the code that implements `UserSerializer` I'm hoping that you know what the fix may be.

If you are not sure or run into more problems, let me know and I will see what I can do to help.

The example data that I have been using to test this code is in a comment above the definition of `submit_answer`:

``` json
{"question":6,"answer":1,"user":{"username":"nicketynick","password":"xyzzy","accuracy_score":0.9,"experience_score":2.2}}
```
